### PR TITLE
[iOS] Fix release notes localization

### DIFF
--- a/lib/releasenotes.dart
+++ b/lib/releasenotes.dart
@@ -15,17 +15,27 @@ class ReleaseNotes {
   ReleaseNotes({
     required this.currentVersion,
     required this.appBundleId,
-  });
+  })  : assert(currentVersion.isNotEmpty),
+        assert(appBundleId.isNotEmpty);
 
-  Future<ReleaseNotesModel?> getReleaseNotes(String lang, String country) async {
+  Future<ReleaseNotesModel?> getReleaseNotes(
+    String lang,
+    String country, {
+    String? locale,
+  }) async {
+    assert(lang.isNotEmpty && lang.trim().length == 2);
+    assert(country.isNotEmpty && country.trim().length == 2);
+    if (Platform.isIOS) {
+      assert(locale != null && locale.isNotEmpty && locale.length == 5);
+    }
+
     final playStoreSearch = PlayStoreSearchAPI();
     final itunesSoreSearch = ITunesSearchAPI();
     String? result;
 
-    late ReleaseNotesModel releaseNotes;
-
     // Get the last version of the store
-    final UpdateCheckerResult updateCheckerResult = await UpdateChecker().checkIfAppHasUpdates(
+    final UpdateCheckerResult updateCheckerResult =
+        await UpdateChecker().checkIfAppHasUpdates(
       currentVersion: currentVersion,
       appBundleId: appBundleId,
       isAndroid: Platform.isAndroid,
@@ -42,14 +52,16 @@ class ReleaseNotes {
       );
       result = PlayStoreResults.releaseNotes(storeInfos!);
     } else {
-      final Map<dynamic, dynamic>? storeInfos = await itunesSoreSearch.lookupByBundleId(
+      final Map<dynamic, dynamic>? storeInfos =
+          await itunesSoreSearch.lookupByBundleId(
         appBundleId,
         country: country,
+        locale: locale ?? "en_US",
       );
       result = ITunesResults.releaseNotes(storeInfos!);
     }
 
-    releaseNotes = ReleaseNotesModel(
+    final ReleaseNotesModel releaseNotes = ReleaseNotesModel(
       notes: result,
       version: updateCheckerResult.newVersion,
     );

--- a/lib/releasenotes.dart
+++ b/lib/releasenotes.dart
@@ -56,7 +56,7 @@ class ReleaseNotes {
           await itunesSoreSearch.lookupByBundleId(
         appBundleId,
         country: country,
-        locale: locale ?? "en_US",
+        locale: locale!,
       );
       result = ITunesResults.releaseNotes(storeInfos!);
     }

--- a/test/releasenotes_test.dart
+++ b/test/releasenotes_test.dart
@@ -15,7 +15,7 @@ void main() {
   test(
     "Should return an ReleaseNotesModel with the app version and notes",
     () async {
-      final ReleaseNotesModel? notes = await releaseNotes.getReleaseNotes("pt", "BR");
+      final ReleaseNotesModel? notes = await releaseNotes.getReleaseNotes("pt", "BR", locale: "pt_BR");
       expect(notes, isA<ReleaseNotesModel>());
       expect(notes?.version, isA<String?>());
       expect(notes?.notes, isA<String?>());


### PR DESCRIPTION
- Fix iOS release notes always return English.
- Added locale (iOS only) property to stick with &lang=locale (ex: &lang=vi_vn) Itunes search query